### PR TITLE
fix(refs T30074): Resolve Path Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Bug Fixes
 - Fix path declarations to have a buildable package
 
+### Features
+- Add prefixClass and prefixClassMixin
+
 ## v0.0.1 
 2022-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+
+## v0.0.2
+2022-11-16
+
+### Bug Fixes
+- Fix path declarations to have a buildable package
+
+## v0.0.1 
+2022-11-15
+
+- This is unfinished and broken. We just need a startingpoint

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ import initGlobalEventListener from './lib/GlobalEventListener'
 import MatchMedia from './lib/MatchMedia'
 import NotificationStoreAdapter from './lib/NotificationStoreAdapter'
 import Pager from './lib/Pager'
+import prefixClass from './utils/prefixClass'
 import SideNav from './lib/SideNav'
 import sortAlphabetically from './utils/sortAlphabetically'
 import Stickier from './lib/Stickier'
@@ -82,6 +83,7 @@ export {
   MatchMedia,
   mimeTypes,
   NotificationStoreAdapter,
+  prefixClass,
   Pager,
   SideNav,
   Stickier,

--- a/lib/ActionMenu.js
+++ b/lib/ActionMenu.js
@@ -40,7 +40,7 @@
  *  To enable highlighting of current item, drop data-actionmenu-current on an item
  *
  */
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../utils/prefixClass'
 
 class ActionMenu {
   constructor (actionMenuElement) {

--- a/lib/AnimateById.js
+++ b/lib/AnimateById.js
@@ -11,7 +11,7 @@
  * Applies an animation of the background color of an element to draw attention to it.
  * The element is selected via the id found in the url fragment  (which has to match an element id).
  */
-import { getAnimationEventName } from 'demosplan-utils'
+import getAnimationEventName from '../utils/getAnimationEventName'
 
 const Animate = () => {
   if (window.location.hash) {

--- a/lib/DpApi.js
+++ b/lib/DpApi.js
@@ -8,7 +8,7 @@
  */
 
 import axios from 'axios'
-import hasOwnProp from '../hasOwnProp'
+import { hasOwnProp } from '../index'
 import { stringify } from 'qs'
 import { v4 as uuid } from 'uuid'
 

--- a/lib/FileInfo.js
+++ b/lib/FileInfo.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { hasOwnProp } from 'demosplan-utils'
+import hasOwnProp from '../utils/hasOwnProp'
 
 const fileTypes = {
   antragx: ['.antragx'],

--- a/lib/HighlightHashLink.js
+++ b/lib/HighlightHashLink.js
@@ -10,7 +10,7 @@
 /**
  * This is a utility function to highlight links in a hash menu.
  */
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../utils/prefixClass'
 
 function highlightActiveLinks (linkSelector) {
   const navLinks = document.querySelectorAll(linkSelector)

--- a/lib/Stickier.js
+++ b/lib/Stickier.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { getScrollTop } from 'demosplan-utils'
+import getScrollTop from '../utils/getScrollTop'
 import MatchMedia from './MatchMedia'
 
 /**

--- a/lib/TableWrapper.js
+++ b/lib/TableWrapper.js
@@ -19,7 +19,7 @@
  *  <element data-table-wrapper="overflow-x-auto">
  *
  */
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../utils/prefixClass'
 
 const wrapElement = function (element, wrapper) {
   element.parentNode.insertBefore(wrapper, element)

--- a/lib/Tabs.js
+++ b/lib/Tabs.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../utils/prefixClass'
 
 /**
  *  Tabs - add behavior to tabbed elements.

--- a/lib/ToggleAnything.js
+++ b/lib/ToggleAnything.js
@@ -8,7 +8,7 @@
  */
 
 import getAnimationEventName from '../utils/getAnimationEventName'
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../utils/prefixClass'
 /**
  *  ToggleAnything
  *  Adds toggle behavior to elements

--- a/lib/ToggleAnything.js
+++ b/lib/ToggleAnything.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { getAnimationEventName } from 'demosplan-utils'
+import getAnimationEventName from '../utils/getAnimationEventName'
 import { prefixClass } from 'demosplan-ui/lib'
 /**
  *  ToggleAnything

--- a/lib/Tooltips.js
+++ b/lib/Tooltips.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../utils/prefixClass'
 /*
  *
  *JS-Solution to display Tooltips.

--- a/lib/validation/dpValidate.js
+++ b/lib/validation/dpValidate.js
@@ -16,9 +16,9 @@
  * See: @DemosPlanCoreBundle/lib/validation/dpValidateMixin.js
  */
 
-import assignHandlerForTrigger from '../utils/assignHandlerForTrigger'
-import { assignHandlersForInputs } from '../utils/assignHandlersForInputs'
-import assignObserver from '../utils/assignObserver'
+import assignHandlerForTrigger from './utils/assignHandlerForTrigger'
+import { assignHandlersForInputs } from './utils/assignHandlersForInputs'
+import assignObserver from './utils/assignObserver'
 
 export default function dpValidate (formId) {
   // If form element is passed as param take it, if not, look for all data-dp-validate elements

--- a/lib/validation/dpValidate.js
+++ b/lib/validation/dpValidate.js
@@ -16,9 +16,9 @@
  * See: @DemosPlanCoreBundle/lib/validation/dpValidateMixin.js
  */
 
-import assignHandlerForTrigger from './utils/assignHandlerForTrigger'
-import { assignHandlersForInputs } from './utils/assignHandlersForInputs'
-import assignObserver from './utils/assignObserver'
+import assignHandlerForTrigger from '../utils/assignHandlerForTrigger'
+import { assignHandlersForInputs } from '../utils/assignHandlersForInputs'
+import assignObserver from '../utils/assignObserver'
 
 export default function dpValidate (formId) {
   // If form element is passed as param take it, if not, look for all data-dp-validate elements

--- a/lib/validation/dpValidateMultiselectDirective.js
+++ b/lib/validation/dpValidateMultiselectDirective.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import validateMultiselect from '../utils/validateMultiselect'
+import { validateMultiselect } from '../../index'
 
 const dpValidateMultiselectDirective = {
   inserted (el, binding, vnode) {

--- a/lib/validation/dpValidateMultiselectDirective.js
+++ b/lib/validation/dpValidateMultiselectDirective.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import validateMultiselect from './utils/validateMultiselect'
+import validateMultiselect from '../utils/validateMultiselect'
 
 const dpValidateMultiselectDirective = {
   inserted (el, binding, vnode) {

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -7,26 +7,24 @@
  * All rights reserved
  */
 
-import assignHandlerForTrigger from '../utils/assignHandlerForTrigger'
-import { assignHandlersForInputs } from '../utils/assignHandlersForInputs'
-import assignObserver from '../utils/assignObserver'
+import assignHandlerForTrigger from './utils/assignHandlerForTrigger'
+import { assignHandlersForInputs } from './utils/assignHandlersForInputs'
+import assignObserver from './utils/assignObserver'
 import dpValidate from './dpValidate'
-import dpValidateMixin from './dpValidateMixin'
 import dpValidateMultiselectDirective from './dpValidateMultiselectDirective'
-import validateDatepicker from '../utils/validateDatepicker'
-import validateEmail from '../utils/validateEmail'
-import validateFieldset from '../utils/validateFieldset'
-import validateForm from '../utils/validateForm'
-import validateInput from '../utils/validateInputField'
-import validateMultiselect from '../utils/validateMultiselect'
-import validateTiptap from '../utils/validateTiptap'
+import validateDatepicker from './utils/validateDatepicker'
+import validateEmail from './utils/validateEmail'
+import validateFieldset from './utils/validateFieldset'
+import validateForm from './utils/validateForm'
+import validateInput from './utils/validateInputField'
+import validateMultiselect from './utils/validateMultiselect'
+import validateTiptap from './utils/validateTiptap'
 
 export {
   assignHandlerForTrigger,
   assignHandlersForInputs,
   assignObserver,
   dpValidate,
-  dpValidateMixin,
   dpValidateMultiselectDirective,
   validateDatepicker,
   validateEmail,

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -7,19 +7,19 @@
  * All rights reserved
  */
 
-import assignHandlerForTrigger from './utils/assignHandlerForTrigger'
-import { assignHandlersForInputs } from './utils/assignHandlersForInputs'
-import assignObserver from './utils/assignObserver'
+import assignHandlerForTrigger from '../utils/assignHandlerForTrigger'
+import { assignHandlersForInputs } from '../utils/assignHandlersForInputs'
+import assignObserver from '../utils/assignObserver'
 import dpValidate from './dpValidate'
 import dpValidateMixin from './dpValidateMixin'
 import dpValidateMultiselectDirective from './dpValidateMultiselectDirective'
-import validateDatepicker from './utils/validateDatepicker'
-import validateEmail from './utils/validateEmail'
-import validateFieldset from './utils/validateFieldset'
-import validateForm from './utils/validateForm'
-import validateInput from './utils/validateInputField'
-import validateMultiselect from './utils/validateMultiselect'
-import validateTiptap from './utils/validateTiptap'
+import validateDatepicker from '../utils/validateDatepicker'
+import validateEmail from '../utils/validateEmail'
+import validateFieldset from '../utils/validateFieldset'
+import validateForm from '../utils/validateForm'
+import validateInput from '../utils/validateInputField'
+import validateMultiselect from '../utils/validateMultiselect'
+import validateTiptap from '../utils/validateTiptap'
 
 export {
   assignHandlerForTrigger,

--- a/lib/validation/utils/assignHandlerForTrigger.js
+++ b/lib/validation/utils/assignHandlerForTrigger.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { addFormHiddenField } from 'demosplan-utils/lib/FormActions'
+import { addFormHiddenField } from '../lib/FormActions'
 import { scrollToVisibleElement } from './helpers'
 import validateForm from './validateForm'
 

--- a/lib/validation/utils/assignHandlerForTrigger.js
+++ b/lib/validation/utils/assignHandlerForTrigger.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { addFormHiddenField } from '../lib/FormActions'
+import { addFormHiddenField } from '../../../index'
 import { scrollToVisibleElement } from './helpers'
 import validateForm from './validateForm'
 

--- a/lib/validation/utils/helpers.js
+++ b/lib/validation/utils/helpers.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-import { getScrollTop } from 'demosplan-utils'
+import getScrollTop from '../../../utils/getScrollTop'
 import { prefixClass } from 'demosplan-ui/lib'
 
 function getAllInputsArray (form) {

--- a/lib/validation/utils/helpers.js
+++ b/lib/validation/utils/helpers.js
@@ -8,7 +8,7 @@
  */
 
 import getScrollTop from '../../../utils/getScrollTop'
-import { prefixClass } from 'demosplan-ui/lib'
+import { prefixClass } from '../../../utils/prefixClass'
 
 function getAllInputsArray (form) {
   return Array.from(form.querySelectorAll('[pattern], [required], input[type="email"], .tiptap__input--hidden.is-required, .multiselect.is-required, fieldset.is-required, [minlength], [maxlength], [data-dp-validate-maxlength], [data-dp-validate-should-equal]'))

--- a/mixins/dpValidateMixin.js
+++ b/mixins/dpValidateMixin.js
@@ -13,10 +13,8 @@
  * Up to date documentation and usage examples can be found here:
  * https://yaits.demos-deutschland.de/w/demosplan/frontend-documentation/frontend-validierung/
  */
-import { errorClass, scrollToVisibleElement } from '../utils/helpers'
-import { assignHandlersForInputs } from '../utils/assignHandlersForInputs'
-import hasOwnProp from '../utils/hasOwnProp'
-import validateForm from '../utils/validateForm'
+import { assignHandlersForInputs, hasOwnProp, validateForm } from '../index'
+import { errorClass, scrollToVisibleElement } from '../lib/validation/utils/helpers'
 
 export default {
   data () {

--- a/mixins/dpValidateMixin.js
+++ b/mixins/dpValidateMixin.js
@@ -13,10 +13,10 @@
  * Up to date documentation and usage examples can be found here:
  * https://yaits.demos-deutschland.de/w/demosplan/frontend-documentation/frontend-validierung/
  */
-import { errorClass, scrollToVisibleElement } from './utils/helpers'
-import { assignHandlersForInputs } from './utils/assignHandlersForInputs'
-import { hasOwnProp } from 'demosplan-utils'
-import validateForm from './utils/validateForm'
+import { errorClass, scrollToVisibleElement } from '../utils/helpers'
+import { assignHandlersForInputs } from '../utils/assignHandlersForInputs'
+import hasOwnProp from '../utils/hasOwnProp'
+import validateForm from '../utils/validateForm'
 
 export default {
   data () {

--- a/mixins/index.js
+++ b/mixins/index.js
@@ -9,10 +9,12 @@
 
 import dpSelectAllMixin from './dpSelectAllMixin'
 import dpValidateMixin from './dpValidateMixin'
+import prefixClassMixin from './prefixClassMixin'
 import tableSelectAllItems from './tableSelectAllItems'
 
 export {
   dpSelectAllMixin,
   dpValidateMixin,
+  prefixClassMixin,
   tableSelectAllItems
 }

--- a/mixins/prefixClassMixin.js
+++ b/mixins/prefixClassMixin.js
@@ -11,7 +11,7 @@
  * This mixin can be to provide the prefixClass method and a prop to control when to prefix and when not.
  *
  */
-import prefixClass from '../lib/prefixClass'
+import { prefixClass } from '../index'
 
 export default {
   methods: {

--- a/mixins/prefixClassMixin.js
+++ b/mixins/prefixClassMixin.js
@@ -1,0 +1,22 @@
+/**
+ * (c) 2010-present DEMOS E-Partizipation GmbH.
+ *
+ * This file is part of the package @demos-europe/demosplan-utils,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+/**
+ * This mixin can be to provide the prefixClass method and a prop to control when to prefix and when not.
+ *
+ */
+import prefixClass from '../lib/prefixClass'
+
+export default {
+  methods: {
+    prefixClass (classList) {
+      return prefixClass(classList)
+    }
+  }
+}

--- a/mixins/prefixClassMixin.js
+++ b/mixins/prefixClassMixin.js
@@ -1,7 +1,7 @@
 /**
  * (c) 2010-present DEMOS E-Partizipation GmbH.
  *
- * This file is part of the package @demos-europe/demosplan-utils,
+ * This file is part of the package @demos-europe/demosplan-js-utils,
  * for more information see the license file.
  *
  * All rights reserved

--- a/mixins/tableSelectAllItems.js
+++ b/mixins/tableSelectAllItems.js
@@ -28,7 +28,7 @@
  *   @items-toggled="handleToggleItem" />
  */
 
-import { uniqueArrayByObjectKey } from 'demosplan-utils'
+import uniqueArrayByObjectKey from '../utils/uniqueArrayByObjectKey'
 
 export default {
   data () {

--- a/mixins/tableSelectAllItems.js
+++ b/mixins/tableSelectAllItems.js
@@ -28,7 +28,7 @@
  *   @items-toggled="handleToggleItem" />
  */
 
-import uniqueArrayByObjectKey from '../utils/uniqueArrayByObjectKey'
+import { uniqueArrayByObjectKey } from '../index'
 
 export default {
   data () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demos-europe/demosplan-utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "private": false,
   "description": "Utility Methods used in demosplan to simplify life",

--- a/utils/prefixClass.js
+++ b/utils/prefixClass.js
@@ -1,7 +1,7 @@
 /**
  * (c) 2010-present DEMOS E-Partizipation GmbH.
  *
- * This file is part of the package @demos-europe/demosplan-utils,
+ * This file is part of the package @demos-europe/demosplan-js-utils,
  * for more information see the license file.
  *
  * All rights reserved

--- a/utils/prefixClass.js
+++ b/utils/prefixClass.js
@@ -1,0 +1,47 @@
+/**
+ * (c) 2010-present DEMOS E-Partizipation GmbH.
+ *
+ * This file is part of the package @demos-europe/demosplan-utils,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+/**
+ * Prefix css classes with a parameter given from the project settings
+ *
+ * @param {String}  classList or querySelector
+ *
+ * @return {String} prefixed classList
+ */
+export default function prefixClass (classList = '') {
+  let prefix = ''
+  if (typeof dplan !== 'undefined' && dplan.settings && dplan.settings.publicCSSClassPrefix) {
+    prefix = dplan.settings.publicCSSClassPrefix
+  }
+
+  let prefixed = ''
+
+  // Don't try to do something if the result should not change
+  if (prefix === '') {
+    return classList
+  }
+
+  // Throw error if the type is wrong
+  if (typeof classList !== 'string') {
+    throw new Error('classList is an' + typeof classList + '. should be String.', classList)
+  }
+
+  /*
+   * Assuming that a querySelector is passed when classList contains a dot, only the class selector parts are prefixed.
+   * In the unlikely case that classes contain dots as part of their names, they will not be prefixed.
+   */
+  const checkClassList = /[.#[]/gi
+  if (checkClassList.test(classList)) {
+    prefixed = classList.replace(/(\.)(\S+)/gi, (cl, m1, m2) => `.${prefix}${m2}`)
+  } else {
+    prefixed = classList.replace(/(\S+)/gi, cl => `${prefix}${cl}`)
+  }
+
+  return prefixed
+}


### PR DESCRIPTION
Just clean up all the path declarations. Something got wrong during the move.

- moved prefixClass and `prefixClassMixin` from ''demosplan-ui` to `demosplan-utils` to avoid a cross referencing (in demosplan-ui its now marked as deprecated, but not removed)

**Ticket** https://yaits.demos-deutschland.de/T30074